### PR TITLE
Googauth auto-install on build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ lib/
 
 # Downloaded on demand
 externals/appengine-java-sdk-*
+externals/google-oauth-client-assembly-*
 
 # secret API key
 war-src/js/openEditor/config.js


### PR DESCRIPTION
When running `./build-console-and-editor.rkt`, auto downloads the Google Authentication Library when necessary from Maven